### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/deploy-pages@v2
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ npm run build
 
 ## GitHub Pages
 
-After building, commit the contents of `dist/` and enable GitHub Pages in your repository settings, pointing it to the `dist/` directory on the `main` branch.
+GitHub Pages is deployed automatically using a workflow in `.github/workflows/pages.yml`. On every push to `main`, the action builds the project and publishes the `dist/` folder.


### PR DESCRIPTION
## Summary
- add GitHub Pages deployment workflow
- document automatic deployment in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685441929ee8832a862936fbcc13a4f6