### PR TITLE
Add sharp search function with tests

### DIFF
--- a/src/engine/search.ts
+++ b/src/engine/search.ts
@@ -1,0 +1,52 @@
+import { Board, Move, Color } from './board';
+
+const PIECE_VALUES: Record<string, number> = {
+  p: 1,
+  n: 3,
+  b: 3,
+  r: 5,
+  q: 9,
+  k: 0,
+};
+
+/** Evaluate a board by simple material count. Positive is good for White. */
+export function evaluateMaterial(board: Board): number {
+  let score = 0;
+  for (const p of board.pieces) {
+    if (!p) continue;
+    const val = PIECE_VALUES[p.toLowerCase()];
+    score += p === p.toUpperCase() ? val : -val;
+  }
+  return score;
+}
+
+function countSafeReplies(b: Board, original: Color): number {
+  const replies = b.generateLegalMoves();
+  const mult = original === 'w' ? 1 : -1;
+  let safe = 0;
+  for (const m of replies) {
+    const nb = b.makeMove(m);
+    const sc = evaluateMaterial(nb) * mult;
+    if (sc <= 0) safe++;
+  }
+  return safe;
+}
+
+/**
+ * Search for the move that gives the opponent the fewest safe replies.
+ */
+export function searchSharpMove(board: Board): Move | null {
+  const moves = board.generateLegalMoves();
+  if (moves.length === 0) return null;
+  let best: Move | null = null;
+  let minSafe = Infinity;
+  for (const m of moves) {
+    const nb = board.makeMove(m);
+    const safe = countSafeReplies(nb, board.turn === 'w' ? 'b' : 'w');
+    if (safe < minSafe) {
+      minSafe = safe;
+      best = m;
+    }
+  }
+  return best;
+}

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,0 +1,24 @@
+import { Board } from '../src/engine/board';
+import { searchSharpMove } from '../src/engine/search';
+
+describe('sharp search', () => {
+  test('captures hanging rook', () => {
+    const b = Board.fromFEN('4k3/8/8/8/4r3/8/4R3/4K3 w - - 0 1');
+    const move = searchSharpMove(b);
+    expect(move).not.toBeNull();
+    if (move) {
+      expect(move.from).toBe(b.index('e2'));
+      expect(move.to).toBe(b.index('e4'));
+    }
+  });
+
+  test('checkmates when possible', () => {
+    const b = Board.fromFEN('4k3/8/8/8/8/8/4R3/4K3 w - - 0 1');
+    const move = searchSharpMove(b);
+    expect(move).not.toBeNull();
+    if (move) {
+      expect(move.from).toBe(b.index('e2'));
+      expect(move.to).toBe(b.index('e8'));
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- implement `searchSharpMove` that chooses moves minimizing safe replies
- evaluate material for simple scoring
- add tests verifying sharp search captures a hanging rook and checkmates when possible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854491bd128832a83b6c89edf64ff04