### PR TITLE
Add web UI for chess engine

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: cp index.html dist/
+      - run: cp src/ui/index.html dist/ui/index.html
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc"
+    "build": "tsc && cp src/ui/index.html dist/ui/index.html"
   },
   "keywords": [],
   "author": "",

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -1,0 +1,44 @@
+import { Board } from '../engine/board';
+import { searchSharpMove } from '../engine/search';
+
+const startFEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+
+function boardToFEN(b: Board): string {
+  let fen = '';
+  for (let r = 0; r < 8; r++) {
+    let empty = 0;
+    for (let f = 0; f < 8; f++) {
+      const p = b.pieceAt(r * 8 + f);
+      if (p) {
+        if (empty > 0) {
+          fen += empty;
+          empty = 0;
+        }
+        fen += p;
+      } else {
+        empty++;
+      }
+    }
+    if (empty > 0) fen += empty;
+    if (r !== 7) fen += '/';
+  }
+  return fen + ` ${b.turn} - - 0 1`;
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  const boardEl = document.getElementById('board') as any;
+  const moveEl = document.getElementById('move') as HTMLElement;
+
+  const board = Board.fromFEN(startFEN);
+  const move = searchSharpMove(board);
+  let moveText = 'none';
+  let displayBoard = board;
+
+  if (move) {
+    moveText = `${board.algebraic(move.from)} → ${board.algebraic(move.to)}`;
+    displayBoard = board.makeMove(move);
+  }
+
+  boardEl.position = boardToFEN(displayBoard);
+  moveEl.textContent = `Engine move: ${moveText}`;
+});

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chess Engine UI</title>
+    <script type="module" src="https://unpkg.com/chessboard-element?module"></script>
+    <script type="module" src="./app.js"></script>
+  </head>
+  <body>
+    <h1>Chess Engine UI</h1>
+    <chess-board id="board" style="width: 400px" position="start"></chess-board>
+    <p id="move"></p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create `/src/ui` with an HTML page and accompanying TypeScript that
  renders a chessboard and shows the engine's move
- copy the UI HTML during build and deployment so GH Pages can serve it

## Testing
- `npm run build`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854612c71d0832aaebc8a30e081c6f4